### PR TITLE
Fix board type and init sequence

### DIFF
--- a/src/BinarySend.py
+++ b/src/BinarySend.py
@@ -17,11 +17,12 @@ extended_delay = 0
 cmdLen = 40
 
 def init_code(): 
-	print 'init seq'
-	GPIO.output(pin, 1)
-	sleep(initHigh)
-	GPIO.output(pin, 0)
-	sleep(initLow)
+	if initSeq == True:
+		print 'init seq'
+		GPIO.output(pin, 1)
+		sleep(initHigh)
+		GPIO.output(pin, 0)
+		sleep(initLow)
 
 def transmit_code(command):
 	print 'transmit'
@@ -105,7 +106,10 @@ def main(argsv):
 				boardType = GPIO.BCM
 		elif opt == '-o':
 			global initSeq
-			initSeq = arg.upper() == 'TRUE'
+			if (arg.upper() == 'TRUE') or (arg.upper() == ' TRUE'):
+				initSeq = True
+			else:
+				initSeq = False
 		elif opt == '-d':
 			global initLow
 			initLow = float(arg) / 1000000

--- a/src/BinarySend.py
+++ b/src/BinarySend.py
@@ -100,7 +100,8 @@ def main(argsv):
 			pin = int(arg)
 		elif opt == '-t':
 			print arg
-			if arg.upper() == 'BOARD':
+			global boardType
+			if (arg.upper() == 'BOARD') or (arg.upper() == ' BOARD'):
 				boardType = GPIO.BOARD
 			else:
 				boardType = GPIO.BCM

--- a/src/ExecShell.js
+++ b/src/ExecShell.js
@@ -28,25 +28,25 @@ ExecShell.prototype.getParams = function (config) {
     }
 
     if (Number.parseFloat(config.initTimeHigh) < 0) {
-        throw 'Initialization bit timing needs to be >= 0';
+        throw 'Initialization bit timing high needs to be >= 0';
     } else {
         params.push('-u ' + Number.parseFloat(config.initTimeHigh));
     }
 
-    if (Number.parseFloat(config.initTimeHigh) < 0) {
-        throw 'Initialization bit timing needs to be >= 0';
+    if (Number.parseFloat(config.initTimeLow) < 0) {
+        throw 'Initialization bit timing low needs to be >= 0';
     } else {
         params.push('-d ' + Number.parseFloat(config.initTimeLow));
     }
 
     if (Number.parseFloat(config.bitLongTime) < 0) {
-        throw 'Bit timing needs to be >= 0';
+        throw 'Bit timing long needs to be >= 0';
     } else {
         params.push('-m ' + Number.parseFloat(config.bitLongTime));
     }
 
     if (Number.parseFloat(config.bitShortTime) < 0) {
-        throw 'Bit timing needs to be >= 0';
+        throw 'Bit timing short needs to be >= 0';
     } else {
         params.push('-l ' + Number.parseFloat(config.bitShortTime));
     }


### PR DESCRIPTION
Fix: setting of board type
Fix: init sequence sending only when selected (fixes https://github.com/SergiuToporjinschi/rf-command/issues/3)

The "fix" with " BOARD" and " TRUE", is just a workaround. It seems that `getopt` has an issue when you type a command line argument with spaces between the option flag and the argument.  
`-o ASDF` will become `' ASDF'` instead of `'ASDF'`  

At least my Rpi and some online compilers have this issue (see https://tio.run/##LYwxDsIwEAR7v@LkKpHsSKE8iYKOH1AgiiCbJJLjM/ZBlNcfjkK1xexM2niieBKZl0SZYfRMiQ2UrSiV8hy50VcfAsGNcnC6VaryYmDIY4Hz/98d01Srq@B77/FhQD8xISPhBx0GXDCix2lPHOE91IqIpUtxL7ERerEB3qvPPw)